### PR TITLE
Add config file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This script automatically confirms Netflix location verification emails. It is d
 2. It searches for Netflix messages that contain the update-primary-location link, then moves the email to the `Gelesen` folder.
 3. Using Playwright, it opens the link and clicks the confirmation button.
 
+Copy `config.env.example` to `config.env` and fill in your mailbox credentials.
+
 This removes the need to manually confirm each viewing session.
 
 **Use responsibly.** Ensure your usage complies with Netflix's terms of service.

--- a/config.env.example
+++ b/config.env.example
@@ -1,0 +1,7 @@
+# Sample configuration for Netflix Autovalidator
+# Rename this file to config.env and fill in your credentials
+
+EMAIL="user@example.com"
+PASSWORD="yourPassword"
+IMAP_SERVER="imap.example.com"
+IMAP_PORT="993"


### PR DESCRIPTION
## Summary
- add `config.env.example` with placeholders
- document how to use the example file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860199455f0832dacc6920b4cce062c